### PR TITLE
修复当分类下第一篇文章是多分类文章时，分类页面的头部按钮高亮不对的问题

### DIFF
--- a/core/meta.php
+++ b/core/meta.php
@@ -31,10 +31,17 @@ class Jasmine_Meta_Row extends Rows
  */
 function isActiveMenu($self, $slug): string
 {
-  if ($self->is("category") || $self->is("post")) {
-    if ($self->category === $slug) {
-      return "jasmine-primary-bg shadow-lg !text-white";
-    }
+  $category = "";
+
+  if ($self->is("category")) {
+    $category = $self->getArchiveSlug();
+  } else if ($self->is("post")) {
+    $category = $self->category;
   }
+
+  if ($category === $slug) {
+    return "jasmine-primary-bg shadow-lg !text-white";
+  }
+
   return "";
 }


### PR DESCRIPTION
假设，我有分类A、B，文章C

C文章分类是多选的，同时选了A、B

当浏览B分类页面时，头部高亮的按钮会是A，而不是B。